### PR TITLE
Add a Dockerfile and a GitHub Actions workflow for testing it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git*
+.husky
+screenshots
+Dockerfile
+README.md

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: Build and test Docker image
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  docker-build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: runtime
+          load: true
+          tags: |
+            recorder
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test Docker image
+        shell: bash
+        run: |
+          docker run --detach --name recorder recorder
+
+          echo "Waiting for container to become healthy..."
+          STATE="$(docker inspect recorder | jq --raw-output '.[0].State.Health.Status')"
+          while [[ "$STATE" != "healthy" ]]; do
+            if [[ "$STATE" != "starting" ]]; then
+              echo "Container is unhealthy. Healthcheck output:"
+              docker inspect recorder | jq --raw-output '.[0].State.Health.Log[-1].Output'
+              exit 1
+            fi
+            sleep 5;
+            echo "Still waiting..."
+            STATE="$(docker inspect recorder | jq --raw-output '.[0].State.Health.Status')"
+          done
+          echo "Container is healthy"
+          docker stop recorder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+COPY . .
+
+RUN yarn install --frozen-lockfile
+RUN yarn build
+
+
+FROM nginx:alpine AS runtime
+
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+HEALTHCHECK --timeout=5s \
+  CMD curl --fail --show-headers http://localhost:80/ || exit 1


### PR DESCRIPTION
To promote easy self-hosting, I wrote this `Dockerfile` that builds and packages the application into a container image.

I also wrote a GitHub Actions workflow that builds the image, runs a container and checks its health.
This workflow will succeed once the container becomes Healthy. Since we are leaving the [HEALTHCHECK](https://docs.docker.com/reference/dockerfile#healthcheck) configuration largely at its defaults, this should succeed 30 seconds after the container is started since `--interval` is being left at its default value of 30 seconds. If the nginx web server fails to come up, this workflow will fail in at most ~90 seconds (`--interval=30`, `--retries=3`) because the container's Status will change to `"unhealthy"` and thus fail the if-check in the workflow.

This image could next be published to Docker Hub, but perhaps that can be a separate PR, since it presumably will require a secret to be added to the GitHub repo.